### PR TITLE
Fix templocation on Linux

### DIFF
--- a/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
+++ b/Plugins/00 Initialize/00 Connection Plugin for vCenter.ps1
@@ -110,8 +110,8 @@ switch ($platform.OSFamily) {
         Get-Module -ListAvailable PowerCLI* | Import-Module
     }
     "Linux" { 
-        $Outputpath = $templocation
         $templocation = "/tmp"
+        $Outputpath = $templocation
         Get-Module -ListAvailable PowerCLI* | Import-Module
     }
     "Windows" { 


### PR DESCRIPTION
$templocation is assigned to $Outputpath before it's defined.